### PR TITLE
#5 - constant naming: NEWLINE -> NewLine

### DIFF
--- a/src/main/scala/de/frosner/replhelper/Helper.scala
+++ b/src/main/scala/de/frosner/replhelper/Helper.scala
@@ -12,7 +12,7 @@ import java.io.PrintStream
  */
 case class Helper[T](classWithHelp: Class[T]) {
 
-  import Helper.NEWLINE
+  import Helper.NewLine
   type Name = String
   type ShortDescription = String
   type LongDescription = String
@@ -48,11 +48,11 @@ case class Helper[T](classWithHelp: Class[T]) {
   def printAllMethods(out: PrintStream) = out.println(
     methods.map {
       case (category, methods) => {
-        s"${Console.BOLD}${category}${Console.RESET} [$simpleClassName]" + NEWLINE + methods.map {
+        s"${Console.BOLD}${category}${Console.RESET} [$simpleClassName]" + NewLine + methods.map {
           case (name, help) => "- " + getMethodSignature(name, help) + s": ${help.shortDescription}"
-        }.mkString(NEWLINE)
+        }.mkString(NewLine)
       }
-    }.mkString(NEWLINE+NEWLINE)
+    }.mkString(NewLine+NewLine)
   )
 
   private def getMethodSignature(name: String, help: Help) = {
@@ -84,17 +84,17 @@ case class Helper[T](classWithHelp: Class[T]) {
         case (name, help) => getMethodSignature(name, help)
       }.map {
         methodWithHelp => getLongDescriptionPrintable(methodWithHelp, out)
-      }.mkString(NEWLINE+NEWLINE)
+      }.mkString(NewLine+NewLine)
     )
   }
 
   private def getLongDescriptionPrintable(methodWithHelp: (String, Help), out: PrintStream) = {
     val (name, help) = methodWithHelp
-    s"${Console.BOLD}${getMethodSignature(name, help)}${Console.RESET} [$simpleClassName]" + NEWLINE + help.longDescription
+    s"${Console.BOLD}${getMethodSignature(name, help)}${Console.RESET} [$simpleClassName]" + NewLine + help.longDescription
   }
 
 }
 
 object Helper {
-  val NEWLINE = System.getProperty("line.separator")
+  val NewLine = System.getProperty("line.separator")
 }

--- a/src/test/scala/de/frosner/replhelper/HelperTest.scala
+++ b/src/test/scala/de/frosner/replhelper/HelperTest.scala
@@ -3,7 +3,7 @@ package de.frosner.replhelper
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 import org.scalatest.{FlatSpec, Matchers}
-import Helper.NEWLINE
+import Helper.NewLine
 
 class HelperTest extends FlatSpec with Matchers {
   
@@ -93,7 +93,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass().getClass)
     helper.printAllMethods(out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
         s"${Console.BOLD}a${Console.RESET} [TestClass]",
         "- help(): short help",
         "- xhelp(): short help",
@@ -109,7 +109,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass().getClass)
     helper.printMethods("help", out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
         s"${Console.BOLD}help()${Console.RESET} [TestClass]",
         "long help",
         ""
@@ -122,7 +122,7 @@ class HelperTest extends FlatSpec with Matchers {
     val helper = Helper(new TestClass2().getClass)
     helper.printMethods("method", out)
     println(result.toString)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
       s"${Console.BOLD}method()${Console.RESET} [TestClass2]",
       "method without parameters",
       "",
@@ -137,7 +137,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass3().getClass)
     helper.printAllMethods(out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
       s"${Console.BOLD}category${Console.RESET} [TestClass3]",
       "- method(1)(2)(3)(4)(5)(6)(7)(8)(9): short",
       ""
@@ -149,7 +149,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass3().getClass)
     helper.printMethods("method", out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
       s"${Console.BOLD}method(1)(2)(3)(4)(5)(6)(7)(8)(9)${Console.RESET} [TestClass3]",
       "long",
       ""
@@ -161,7 +161,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(DummyObjectThatIsNoCompanion.getClass)
     helper.printMethods("method", out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
       s"${Console.BOLD}method()${Console.RESET} [DummyObjectThatIsNoCompanion]",
       "l",
       ""
@@ -173,7 +173,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(DummyObjectThatIsNoCompanion.getClass)
     helper.printAllMethods(out)
-    result.toString.split(NEWLINE, -1) shouldBe Array(
+    result.toString.split(NewLine, -1) shouldBe Array(
       s"${Console.BOLD}c${Console.RESET} [DummyObjectThatIsNoCompanion]",
       "- method(): s",
       ""

--- a/src/test/scala/de/frosner/replhelper/HelperTest.scala
+++ b/src/test/scala/de/frosner/replhelper/HelperTest.scala
@@ -3,7 +3,7 @@ package de.frosner.replhelper
 import java.io.{ByteArrayOutputStream, PrintStream}
 
 import org.scalatest.{FlatSpec, Matchers}
-import Helper.NewLine
+import Helper.NEWLINE
 
 class HelperTest extends FlatSpec with Matchers {
   
@@ -93,7 +93,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass().getClass)
     helper.printAllMethods(out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
         s"${Console.BOLD}a${Console.RESET} [TestClass]",
         "- help(): short help",
         "- xhelp(): short help",
@@ -109,7 +109,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass().getClass)
     helper.printMethods("help", out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
         s"${Console.BOLD}help()${Console.RESET} [TestClass]",
         "long help",
         ""
@@ -122,7 +122,7 @@ class HelperTest extends FlatSpec with Matchers {
     val helper = Helper(new TestClass2().getClass)
     helper.printMethods("method", out)
     println(result.toString)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
       s"${Console.BOLD}method()${Console.RESET} [TestClass2]",
       "method without parameters",
       "",
@@ -137,7 +137,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass3().getClass)
     helper.printAllMethods(out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
       s"${Console.BOLD}category${Console.RESET} [TestClass3]",
       "- method(1)(2)(3)(4)(5)(6)(7)(8)(9): short",
       ""
@@ -149,7 +149,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(new TestClass3().getClass)
     helper.printMethods("method", out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
       s"${Console.BOLD}method(1)(2)(3)(4)(5)(6)(7)(8)(9)${Console.RESET} [TestClass3]",
       "long",
       ""
@@ -161,7 +161,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(DummyObjectThatIsNoCompanion.getClass)
     helper.printMethods("method", out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
       s"${Console.BOLD}method()${Console.RESET} [DummyObjectThatIsNoCompanion]",
       "l",
       ""
@@ -173,7 +173,7 @@ class HelperTest extends FlatSpec with Matchers {
     val out = new PrintStream(result)
     val helper = Helper(DummyObjectThatIsNoCompanion.getClass)
     helper.printAllMethods(out)
-    result.toString.split(NewLine, -1) shouldBe Array(
+    result.toString.split(NEWLINE, -1) shouldBe Array(
       s"${Console.BOLD}c${Console.RESET} [DummyObjectThatIsNoCompanion]",
       "- method(): s",
       ""


### PR DESCRIPTION
This still breaks with the codacy regExp (I think), but it's consistent with the Scala style guide http://docs.scala-lang.org/style/naming-conventions.html
